### PR TITLE
Re-design the session API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustls = { version = "0.11.0", optional = true }
 tokio-rustls = { version = "0.4.0", optional = true }
 fnv = "1.0.6"
 hyperx = "0.12.0"
-cookie = { version = "0.10.1", features = ["secure", "percent-encode"], optional = true }
+cookie = { version = "0.10.1", features = ["percent-encode"] }
 serde = { version = "1.0.66", features = ["derive"] }
 serde_json = "1.0.20"
 state = "0.4"
@@ -52,6 +52,6 @@ tokio-process = "0.2.2"
 
 [features]
 default = ["tls", "session"]
-session = ["cookie"]
+session = ["cookie/secure"]
 tls = ["rustls", "tokio-rustls"]
 nightly = []

--- a/examples/session.rs
+++ b/examples/session.rs
@@ -1,0 +1,30 @@
+extern crate tsukuyomi;
+
+#[cfg(not(feature = "session"))]
+fn main() {
+    println!("This example works only if the feature 'session' is enabled");
+}
+
+#[cfg(feature = "session")]
+fn main() -> tsukuyomi::AppResult<()> {
+    use tsukuyomi::future::{ready, Ready};
+    use tsukuyomi::session::ContextSessionExt;
+    use tsukuyomi::{App, Error};
+
+    let app = App::builder()
+        .mount("/", |r| {
+            r.get("/", |cx| -> Ready<_> {
+                ready((|| -> Result<String, Error> {
+                    if let Some(foo) = cx.session().get::<String>("foo")? {
+                        Ok(format!("foo = {}\n", foo))
+                    } else {
+                        cx.session().set::<String>("foo", "bar".into())?;
+                        Ok("set: foo = bar\n".into())
+                    }
+                })())
+            });
+        })
+        .finish()?;
+
+    tsukuyomi::run(app)
+}

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -153,11 +153,9 @@ impl AppServiceFuture {
         }
     }
 
-    #[allow(unused_mut)]
     fn handle_response(&mut self, output: Output, cx: ContextParts) -> Result<Response<Body>, CritError> {
         let (mut response, handler) = output.deconstruct();
 
-        #[cfg(feature = "session")]
         cx.cookies.append_to(response.headers_mut());
 
         if let Some(handler) = handler {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 // #![deny(bare_trait_objects)]
 
 extern crate bytes;
+extern crate cookie;
 #[macro_use]
 extern crate failure;
 extern crate fnv;
@@ -33,9 +34,6 @@ extern crate tokio_tcp;
 #[cfg(unix)]
 extern crate tokio_uds;
 
-#[cfg(feature = "session")]
-extern crate cookie;
-
 #[cfg(feature = "tls")]
 extern crate rustls;
 #[cfg(feature = "tls")]
@@ -53,6 +51,9 @@ pub mod output;
 pub mod router;
 pub mod server;
 pub mod upgrade;
+
+#[cfg(feature = "session")]
+pub mod session;
 
 /// The definition of statically typed headers.
 ///
@@ -76,9 +77,6 @@ pub mod mime {
     pub use self::mime::*;
     pub use self::mime::{Mime, Name, Params};
 }
-
-#[cfg(feature = "session")]
-mod session;
 
 #[doc(inline)]
 pub use app::App;


### PR DESCRIPTION
The new session API separates with the implementation of Cookie manager.

### TODOs
- [ ] Custom session backend
- [x] Add an example