### PR TITLE
fix(*): enforce implicit access to Input via scoped TLS

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -9,7 +9,7 @@ fn main() -> tsukuyomi::AppResult<()> {
 
     let app = App::builder()
         .mount("/", |r| {
-            r.get("/", |_| ready("Hello, world!\n"));
+            r.get("/", || ready("Hello, world!\n"));
         })
         .finish()?;
 

--- a/examples/db/src/api/get_posts.rs
+++ b/examples/db/src/api/get_posts.rs
@@ -6,7 +6,7 @@ use tokio_threadpool::blocking;
 
 use tsukuyomi::json::Json;
 use tsukuyomi::output::HttpResponse;
-use tsukuyomi::{Error, Input};
+use tsukuyomi::Error;
 
 use conn::get_conn;
 use model::Post;
@@ -18,8 +18,8 @@ pub struct Response {
 
 impl HttpResponse for Response {}
 
-pub fn get_posts(cx: &Input) -> impl Future<Item = Json<Response>, Error = Error> + Send + 'static {
-    get_conn(cx)
+pub fn get_posts() -> impl Future<Item = Json<Response>, Error = Error> + Send + 'static {
+    get_conn()
         .and_then(|conn| {
             let query = {
                 use schema::posts::dsl::*;

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -22,7 +22,7 @@ struct User {
 impl HttpResponse for User {}
 
 // async fn get_json(_: &Input) -> Json<User> { ... }
-fn get_json(_: &Input) -> Ready<Json<User>> {
+fn get_json() -> Ready<Json<User>> {
     ready(Json(User {
         name: "Sakura Kinomoto".into(),
         age: 13,
@@ -30,10 +30,12 @@ fn get_json(_: &Input) -> Ready<Json<User>> {
 }
 
 // async fn read_json_payload(_: &Input) -> tsukuyomi::Result<Json<User>> { ... }
-fn read_json_payload(ctxt: &Input) -> impl Future<Item = Json<User>, Error = Error> + Send + 'static {
-    ctxt.body().read_all().convert_to::<Json<User>>().map(|user| {
-        info!("Received: {:?}", user);
-        user
+fn read_json_payload() -> impl Future<Item = Json<User>, Error = Error> + Send + 'static {
+    Input::with(|input| {
+        input.body().read_all().convert_to::<Json<User>>().map(|user| {
+            info!("Received: {:?}", user);
+            user
+        })
     })
 }
 

--- a/examples/lines/src/main.rs
+++ b/examples/lines/src/main.rs
@@ -14,13 +14,15 @@ use tsukuyomi::future::{ready, Ready};
 use tsukuyomi::upgrade::Upgrade;
 use tsukuyomi::{App, Input};
 
-fn index(cx: &Input) -> Ready<tsukuyomi::Result<Upgrade>> {
-    ready(lines::start(cx, |line| {
-        if !line.is_empty() {
-            Some(format!(">> {}", line))
-        } else {
-            None
-        }
+fn index() -> Ready<tsukuyomi::Result<Upgrade>> {
+    ready(Input::with(|input| {
+        lines::start(input, |line| {
+            if !line.is_empty() {
+                Some(format!(">> {}", line))
+            } else {
+                None
+            }
+        })
     }))
 }
 

--- a/examples/routing/src/main.rs
+++ b/examples/routing/src/main.rs
@@ -9,15 +9,15 @@ fn main() -> tsukuyomi::AppResult<()> {
 
     let app = App::builder()
         .mount("/", |r| {
-            // r.get("/", async |_: &_| "Hello, world\n");
-            r.get("/", |_| ready("Hello, world\n"));
+            // r.get("/", async || "Hello, world\n");
+            r.get("/", || ready("Hello, world\n"));
 
-            r.get("/api/:name", |cx: &Input| {
-                ready(format!("Hello, {}\n", &cx.params()[0]))
+            r.get("/api/:name", || {
+                ready(Input::with(|input| format!("Hello, {}\n", &input.params()[0])))
             });
 
-            r.get("/static/*path", |cx: &Input| {
-                ready(format!("path = {}\n", &cx.params()[0]))
+            r.get("/static/*path", || {
+                ready(Input::with(|input| format!("path = {}\n", &input.params()[0])))
             });
         })
         .finish()?;

--- a/examples/session/src/main.rs
+++ b/examples/session/src/main.rs
@@ -2,20 +2,20 @@ extern crate tsukuyomi;
 
 use tsukuyomi::future::{ready, Ready};
 use tsukuyomi::session::InputSessionExt;
-use tsukuyomi::{App, Error};
+use tsukuyomi::{App, Error, Input};
 
 fn main() -> tsukuyomi::AppResult<()> {
     let app = App::builder()
         .mount("/", |r| {
-            r.get("/", |cx| -> Ready<_> {
-                ready((|| -> Result<String, Error> {
-                    if let Some(foo) = cx.session().get::<String>("foo")? {
+            r.get("/", || -> Ready<_> {
+                ready(Input::with(|input| -> Result<String, Error> {
+                    if let Some(foo) = input.session().get::<String>("foo")? {
                         Ok(format!("foo = {}\n", foo))
                     } else {
-                        cx.session().set::<String>("foo", "bar".into())?;
+                        input.session().set::<String>("foo", "bar".into())?;
                         Ok("set: foo = bar\n".into())
                     }
-                })())
+                }))
             });
         })
         .finish()?;

--- a/examples/template-askama/src/main.rs
+++ b/examples/template-askama/src/main.rs
@@ -32,8 +32,8 @@ struct Hello {
     name: String,
 }
 
-fn index(cx: &Input) -> Ready<Template<Hello>> {
-    let name = cx.params()[0].to_owned();
+fn index() -> Ready<Template<Hello>> {
+    let name = Input::with(|input| input.params()[0].to_owned());
     ready(Template(Hello { name: name }))
 }
 

--- a/examples/unix-socket/src/main.rs
+++ b/examples/unix-socket/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> tsukuyomi::AppResult<()> {
 
     let app = App::builder()
         .mount("/", |r| {
-            r.get("/", |_| ready("Hello"));
+            r.get("/", || ready("Hello"));
         })
         .finish()?;
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -14,8 +14,6 @@ use error::handler::{DefaultErrorHandler, ErrorHandler};
 use modifier::Modifier;
 use router::{self, Mount, Router};
 
-scoped_thread_local!(static STATE: AppState);
-
 /// The global and shared variables used throughout the serving an HTTP application.
 pub struct AppState {
     router: Router,
@@ -33,10 +31,6 @@ impl fmt::Debug for AppState {
 }
 
 impl AppState {
-    pub(crate) fn set<R>(&self, f: impl FnOnce() -> R) -> R {
-        STATE.set(self, f)
-    }
-
     /// Returns the reference to `Router` contained in this value.
     pub fn router(&self) -> &Router {
         &self.router
@@ -115,12 +109,12 @@ impl AppBuilder {
     /// # Examples
     ///
     /// ```
-    /// # use tsukuyomi::{App, Input};
+    /// # use tsukuyomi::App;
     /// # use tsukuyomi::future::ready;
-    /// # let index = |_: &Input| ready("a");
-    /// # let find_post = |_: &Input| ready("a");
-    /// # let all_posts = |_: &Input| ready("a");
-    /// # let add_post = |_: &Input| ready("a");
+    /// # let index = || ready("a");
+    /// # let find_post = || ready("a");
+    /// # let all_posts = || ready("a");
+    /// # let add_post = || ready("a");
     /// let app = App::builder()
     ///     .mount("/", |r| { r.get("/", index); })
     ///     .mount("/api/v1/", |r| {

--- a/src/modifier.rs
+++ b/src/modifier.rs
@@ -7,12 +7,11 @@ use std::fmt;
 
 use error::Error;
 use future::{Future, Poll};
-use input::Input;
 use output::Output;
 
 pub trait Modifier {
-    fn before_handle(&self, input: &Input) -> BeforeHandle;
-    fn after_handle(&self, input: &Input, output: Output) -> AfterHandle;
+    fn before_handle(&self) -> BeforeHandle;
+    fn after_handle(&self, output: Output) -> AfterHandle;
 }
 
 // ==== BeforeHandle ====

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -5,7 +5,6 @@ use std::mem;
 
 use error::Error;
 use future::Future;
-use input::Input;
 use output::Responder;
 
 use super::recognizer::Recognizer;
@@ -91,7 +90,7 @@ pub struct Builder {
 impl Builder {
     fn add_route<H, R>(&mut self, base: &str, path: &str, method: Method, handler: H) -> &mut Self
     where
-        H: Fn(&Input) -> R + Send + Sync + 'static,
+        H: Fn() -> R + Send + Sync + 'static,
         R: Future + Send + 'static,
         R::Output: Responder,
     {
@@ -174,7 +173,7 @@ macro_rules! impl_methods_for_mount {
         #[inline]
         pub fn $name<H, R>(&mut self, path: &str, handler: H) -> &mut Self
         where
-            H: Fn(&Input) -> R + Send + Sync + 'static,
+            H: Fn() -> R + Send + Sync + 'static,
             R: Future + Send + 'static,
             R::Output: Responder,
         {
@@ -187,7 +186,7 @@ impl<'a> Mount<'a> {
     /// Adds a route with the provided path, method and handler.
     pub fn route<H, R>(&mut self, path: &str, method: Method, handler: H) -> &mut Self
     where
-        H: Fn(&Input) -> R + Send + Sync + 'static,
+        H: Fn() -> R + Send + Sync + 'static,
         R: Future + Send + 'static,
         R::Output: Responder,
     {


### PR DESCRIPTION
Removes the reference to `Input` from arguments in the signature of handlers and the methods of `Modifier`.
This is a workaround to avoid capturing the lifetime of `&Input` when using the `async/await` syntax.

**BREAKING CHANGES:** The signature of handler function is changed.