### PR TITLE
revert to implicit access to the global state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ cookie = { version = "0.10.1", features = ["percent-encode"] }
 serde = { version = "1.0.66", features = ["derive"] }
 serde_json = "1.0.20"
 state = "0.4"
+scoped-tls = "0.1.2"
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = "0.2.0"

--- a/examples/db/Cargo.toml
+++ b/examples/db/Cargo.toml
@@ -17,4 +17,5 @@ dotenv = "0.9.0"
 failure = { version = "0.1.1", features = ["derive"] }
 futures = "0.1.21"
 serde = { version = "1.0.0", features = ["derive"] }
+tokio-executor = "0.1"
 tokio-threadpool = "0.1"

--- a/examples/db/src/api/get_posts.rs
+++ b/examples/db/src/api/get_posts.rs
@@ -1,14 +1,11 @@
 use diesel::prelude::*;
-use futures::future::poll_fn;
 use futures::prelude::*;
-use futures::Async;
-use tokio_threadpool::blocking;
 
 use tsukuyomi::json::Json;
 use tsukuyomi::output::HttpResponse;
-use tsukuyomi::Error;
+use tsukuyomi::{App, Error};
 
-use conn::get_conn;
+use conn::{get_conn, run_blocking};
 use model::Post;
 
 #[derive(Debug, Serialize)]
@@ -19,16 +16,11 @@ pub struct Response {
 impl HttpResponse for Response {}
 
 pub fn get_posts() -> impl Future<Item = Json<Response>, Error = Error> + Send + 'static {
-    get_conn()
+    App::with_global(get_conn)
         .and_then(|conn| {
-            let query = {
+            run_blocking(move || {
                 use schema::posts::dsl::*;
-                posts.limit(20)
-            };
-            poll_fn(move || {
-                try_ready!(blocking(|| query.load::<Post>(&*conn)))
-                    .map(Async::Ready)
-                    .map_err(Into::into)
+                posts.limit(20).load::<Post>(&*conn)
             })
         })
         .map_err(Error::internal_server_error)

--- a/examples/db/src/main.rs
+++ b/examples/db/src/main.rs
@@ -1,12 +1,11 @@
 #[macro_use]
 extern crate diesel;
 extern crate dotenv;
-#[macro_use]
 extern crate failure;
-#[macro_use]
 extern crate futures;
 #[macro_use]
 extern crate serde;
+extern crate tokio_executor;
 extern crate tokio_threadpool;
 extern crate tsukuyomi;
 

--- a/src/input/input.rs
+++ b/src/input/input.rs
@@ -89,10 +89,6 @@ impl Input {
             .expect("The wrong route ID")
     }
 
-    pub(crate) fn route_id(&self) -> usize {
-        self.parts.route
-    }
-
     /// Returns a proxy object for accessing parameters extracted by the router.
     pub fn params(&self) -> Params {
         Params {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ extern crate hyper;
 extern crate hyperx;
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate scoped_tls;
 extern crate serde;
 #[macro_use]
 extern crate serde_json;

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,6 +7,7 @@ use serde::ser::Serialize;
 use serde_json;
 use std::fmt;
 
+use app::AppState;
 use error::Error;
 use input::Input;
 
@@ -99,9 +100,11 @@ impl<'a> Session<'a> {
     }
 
     fn with_private<R>(&mut self, f: impl FnOnce(PrivateJar) -> R) -> Result<R, Error> {
-        let key = self.input.global().session().secret_key().clone();
-        let mut jar = self.input.cookies()?;
-        Ok(f(jar.private(&key)))
+        AppState::with_get(|global| {
+            let key = global.session().secret_key();
+            let mut jar = self.input.cookies()?;
+            Ok(f(jar.private(&key)))
+        })
     }
 }
 


### PR DESCRIPTION
Since `AppState` has no mutability throughout serving the application unlike `Input`, the resource management should be  independent to `Input` (which does not allow duplicated borrow).