### PR TITLE
revert(future): remove some conversion methods from/to std::task::Poll<T>

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,9 +32,9 @@ test_script:
   - cargo clean
   - cargo test
   - cargo test --no-default-features
-  - if [%TOOLCHAIN%]==[nightly] (
-      cargo test --features nightly
-    )
+  #- if [%TOOLCHAIN%]==[nightly] (
+  #    cargo test --features nightly
+  #  )
   # FIXME: move examples to independent repository.
   - cargo test -p example-basic
   # - cargo test -p example-diesel

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
         - cargo clean
         - cargo test
         - cargo test --no-default-features
-        - cargo test --features nightly
+        #- cargo test --features nightly
         # examples
         - cargo test -p example-basic
         - cargo test -p example-diesel

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,4 +72,4 @@ tokio-uds = "0.2.0"
 default = ["tls", "secure"]
 secure = ["cookie/secure"]
 tls = ["rustls", "tokio-rustls"]
-nightly = []
+# nightly = []

--- a/src/future.rs
+++ b/src/future.rs
@@ -7,9 +7,6 @@
 
 use futures;
 
-#[cfg(feature = "nightly")]
-use std::task as stdtask;
-
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum Poll<T> {
     Ready(T),
@@ -94,26 +91,6 @@ impl<T, E> Into<Result<futures::Async<T>, E>> for Poll<T> {
         match self {
             Poll::Ready(v) => Ok(futures::Async::Ready(v)),
             Poll::Pending => Ok(futures::Async::NotReady),
-        }
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl<T> From<stdtask::Poll<T>> for Poll<T> {
-    fn from(p: stdtask::Poll<T>) -> Poll<T> {
-        match p {
-            stdtask::Poll::Ready(v) => Poll::Ready(v),
-            stdtask::Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl<T> Into<stdtask::Poll<T>> for Poll<T> {
-    fn into(self) -> stdtask::Poll<T> {
-        match self {
-            Poll::Ready(v) => stdtask::Poll::Ready(v),
-            Poll::Pending => stdtask::Poll::Pending,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 #![deny(unused_extern_crates)]
 #![deny(warnings)]
 #![deny(bare_trait_objects)]
-#![cfg_attr(feature = "nightly", feature(futures_api))]
 
 extern crate bytes;
 extern crate cookie;


### PR DESCRIPTION
The support for standard task system is partial and unnecessary at this version.
To avoid confusion, removing some implementations away temporarily.

The migration will start as soon as futures-0.3 reaches the production-ready stage.