### PR TITLE
fix(router): change the argument type of `Route::handle`

### DIFF
--- a/examples/codegen/src/main.rs
+++ b/examples/codegen/src/main.rs
@@ -6,7 +6,7 @@ extern crate tsukuyomi;
 
 use futures::prelude::{await, Future};
 use tsukuyomi::prelude::handler;
-use tsukuyomi::{App, Error, Handler, Input};
+use tsukuyomi::{App, Error, Input};
 
 #[handler]
 fn ready_handler() -> &'static str {
@@ -28,9 +28,9 @@ fn await_handler() -> tsukuyomi::Result<String> {
 fn main() -> tsukuyomi::AppResult<()> {
     let app = App::builder()
         .mount("/", |m| {
-            m.get("/ready").handle(Handler::new(ready_handler));
-            m.post("/async").handle(Handler::new(async_handler));
-            m.post("/await").handle(Handler::new(await_handler));
+            m.get("/ready").handle(ready_handler);
+            m.post("/async").handle(async_handler);
+            m.post("/await").handle(await_handler);
         })
         .finish()?;
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -17,6 +17,16 @@ impl fmt::Debug for Handler {
     }
 }
 
+impl<F> From<F> for Handler
+where
+    F: Fn(&mut Input) -> Handle + Send + Sync + 'static,
+{
+    #[inline(always)]
+    fn from(handler: F) -> Handler {
+        Handler::new(handler)
+    }
+}
+
 impl Handler {
     #[doc(hidden)]
     pub fn new(handler: impl Fn(&mut Input) -> Handle + Send + Sync + 'static) -> Handler {

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -396,9 +396,9 @@ impl<'a, 'b> Route<'a, 'b> {
     }
 
     /// Finishes this session and registers an endpoint with given handler.
-    pub fn handle(self, handler: Handler) {
+    pub fn handle(self, handler: impl Into<Handler>) {
         let uri = uri::join_all(self.mount.prefix.iter().chain(Some(&self.suffix)));
-        let endpoint = Endpoint::new(uri, self.method, handler);
+        let endpoint = Endpoint::new(uri, self.method, handler.into());
         self.mount.builder.endpoints.push(endpoint);
     }
 }


### PR DESCRIPTION
The type accepted by `Route::handle` extends to a generic type which implements the conversion to `Handler`.